### PR TITLE
Further updates to resolve subscription confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # palmctl
 
-This is the command-line interface tool for IBM Hybrid Cloud Mesh (Mesh). It is used to configure and manage the [Mesh product](https://www.ibm.com/products/hybrid-cloud-mesh).
+This is the command-line interface tool for IBM Hybrid Cloud Mesh (Mesh). It is used to configure and manage the [Mesh product](https://www.ibm.com/products/hybrid-cloud-mesh). To read Mesh release notes, information about getting started, Red Hat Service Interconnect, and using the UI, CLI, and API, see the product documentation at [https://www.ibm.com/docs/hybrid-cloud-mesh](https://www.ibm.com/docs/hybrid-cloud-mesh).
 
-You can subscribe to Mesh at [My IBM](https://myibm.ibm.com/). After you subscribe, go to [Using the CLI](https://www.ibm.com/docs/en/hybrid-cloud-mesh?topic=using-cli) in the [Mesh documentation](https://www.ibm.com/docs/en/hybrid-cloud-mesh) for a brief overview of `palmctl`, installation instructions, and some examples.
+You can subscribe to Mesh at [My IBM](https://myibm.ibm.com/). After you subscribe, go to [Using the CLI](https://www.ibm.com/docs/en/hybrid-cloud-mesh?topic=using-cli) in the Mesh documentation for a brief overview of `palmctl`, installation instructions, and some examples.


### PR DESCRIPTION
A stakeholder commented:  "a reader would be likely to think that they have to subscribe to Mesh before they can read the documentation. I think it would be better if that perception did not exist because some users (working for _potential_ Mesh customers) would want to read the documentation _first_."
These changes are to resolve that problem.